### PR TITLE
Use the GIT SHA for tagging Docker images

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "node handler.js",
     "build:docker": "docker build . -t biowink/contentful-backup -f docker/app.Dockerfile",
     "start:docker": "docker run -t -i -p 80:80 --rm --name contentful-backup biowink/contentful-backup",
-    "deploy": "scripts/deployToDockerHub.sh"
+    "deploy": "GIT_SHA=`git rev-parse HEAD` scripts/deployToDockerHub.sh"
   },
   "dependencies": {
     "aws-sdk": "^2.662.0",

--- a/scripts/deployToDockerHub.sh
+++ b/scripts/deployToDockerHub.sh
@@ -1,10 +1,5 @@
 #!/bin/bash -xe
 
-get_timestamp() 
-{
-    date '+%Y-%m-%d.%H-%M-%S%Z'
-}
-
 build_docker_image ()
 {
     yarn build:docker
@@ -12,12 +7,12 @@ build_docker_image ()
 
 tag_docker_image ()
 {
-    docker tag biowink/helloclue.com "biowink/contentful-backup:$(get_timestamp)"
+    docker tag biowink/contentful-backup "biowink/contentful-backup:${GIT_SHA}"
 }
 
 push_to_dockerhub ()
 {
-    docker push "biowink/contentful-backup:$(get_timestamp)"
+    docker push "biowink/contentful-backup:${GIT_SHA}"
 }
 
 build_docker_image


### PR DESCRIPTION
No JIRA ticket. I'm making this modification because Max suggested using the GIT SHA instead of a timestamp for tagging the Docker image.